### PR TITLE
fix: find files in dashbord

### DIFF
--- a/lua/plugins/dashboard.lua
+++ b/lua/plugins/dashboard.lua
@@ -51,7 +51,7 @@ local opts = {
         icon = "",
         desc = "Find files",
         key = "f",
-        action = "TelescopeFindFiles",
+        action = "Telescope find_files",
       },
       {
         icon = "",


### PR DESCRIPTION
This pull request includes a small change to the `lua/plugins/dashboard.lua` file. The change updates the `action` field for the "Find files" dashboard option to use the correct command syntax for Telescope.